### PR TITLE
Adds getData(), setData() and clearData() methods.

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -82,6 +82,13 @@ class Connection implements ConnectionInterface
     protected $options = array();
 
     /**
+     * Runtime connection data.
+     *
+     * @var array
+     */
+    protected $data = array();
+
+    /**
      * Constructor to accept property values.
      *
      * @param array $config Associative array keyed by property name
@@ -324,5 +331,38 @@ class Connection implements ConnectionInterface
     public function getOption($name)
     {
         return isset($this->options[$name]) ? $this->options[$name] : null;
+    }
+
+    /**
+     * Implements ConnectionInterface::setData().
+     *
+     * @param string $name Data key
+     * @param mixed $value Data value
+     * @return $this
+     */
+    public function setData($name, $value)
+    {
+        $this->data[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Implements ConnectionInterface::getData().
+     *
+     * @param string $name Data key
+     * @return mixed
+     */
+    public function getData($name)
+    {
+        return isset($this->data[$name]) ? $this->data[$name] : null;
+    }
+
+    /**
+     * Implements ConnectionInterface::clearData().
+     */
+    public function clearData()
+    {
+        $this->data = array();
     }
 }

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -162,4 +162,25 @@ interface ConnectionInterface
      * @return mixed
      */
     public function getOption($name);
+
+    /**
+     * Sets a runtime connection data field.
+     *
+     * @param string $name Data key
+     * @param mixed $value Data value
+     */
+    public function setData($name, $value);
+
+    /**
+     * Returns a runtime connection data field.
+     *
+     * @param string $name Data key
+     * @return mixed
+     */
+    public function getData($name);
+
+    /**
+     * Clears all runtime connection data.
+     */
+    public function clearData();
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -230,6 +230,28 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->connection->getOption('bar'));
     }
 
+    /**
+     * Tests setData(), getData() and clearData().
+     */
+    public function testDataFunctions()
+    {
+        $this->assertNull($this->connection->getOption('foo'));
+        $this->assertNull($this->connection->getOption('bar'));
+
+        $this->connection->setData('foo', 'bar');
+        $this->assertSame('bar', $this->connection->getData('foo'));
+
+        $this->connection->setData('foo', 'baz');
+        $this->assertSame('baz', $this->connection->getData('foo'));
+
+        $this->connection->setData('bar', 'quux');
+        $this->assertSame('quux', $this->connection->getData('bar'));
+
+        $this->connection->clearData();
+        $this->assertNull($this->connection->getData('foo'));
+        $this->assertNull($this->connection->getData('bar'));
+    }
+
     public function testFluentInterface()
     {
         $this->assertSame($this->connection, $this->connection->setServerHostname('hostname'));
@@ -241,5 +263,6 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->connection, $this->connection->setServername('servername'));
         $this->assertSame($this->connection, $this->connection->setRealname('realname'));
         $this->assertSame($this->connection, $this->connection->setOption('foo', 'bar'));
+        $this->assertSame($this->connection, $this->connection->setData('foo', 'bar'));
     }
 }


### PR DESCRIPTION
Creates a distinction between "options" and runtime connection data. Currently, there are no distinctions: runtime data like the stream handler are stored as "options" alongside true configuration options like SSL.

With this change, options should only be set at configuration time (ie. before establishing socket connections), and the data functions would then be used for storing data specific to the "live" IRC connection, such as the stream handler, channel lists, etc.

`Connection::clearData()` can be called during stream clean-up functions to clear all runtime data ready for the connection object to be re-used if desired.