### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
 
 matrix:
   allow_failures:
-    - php: 7
+    - php: hhvm
 
 before_script:
   - composer self-update


### PR DESCRIPTION
Updating travis.yml to stop allowing PHP 7 failures. 